### PR TITLE
Update distro-specific links

### DIFF
--- a/users/download.html
+++ b/users/download.html
@@ -43,8 +43,7 @@ document.write("<a class='download donate' href='"+file+"'><strong>Download Geph
 <a class="donate" href="https://launchpad.net/gephi/0.8/0.8.2beta/+download/gephi-0.8.2-beta.sources.tar.gz">Download Gephi 0.8.2-beta sources</a><br />
 <a href="https://launchpad.net/gephi/+download">Download Older Versions</a></p>
 <p><strong>Specific Linux distributions:</strong><br />
-<a class="donate" href="https://aur.archlinux.org/packages.php?ID=43580">Download Gephi 0.8-alpha for ArchLinux</a> (now deprecated)<br />
-Ubuntu users: install a daily build by adding <a href="https://launchpad.net/~rockclimb/+archive/gephi-daily">ppa:rockclimb/gephi-daily</a> to your system&#8217;s Software Sources</p>
+<a class="donate" href="https://aur.archlinux.org/packages.php?ID=43580">Download Gephi 0.8.2-beta for ArchLinux</a><br />
 <p><strong>Sources:</strong><br />
 Gephi uses <a href="https://github.com/gephi/gephi">GitHub</a> to host the source code and track issues. The <a href="https://github.com/gephi/gephi">trunk</a> repository is the most up-to-date version but may be unstable. The last stable version is located in the most recent release branch.</p>
 <hr />


### PR DESCRIPTION
- ArchLinux has updated the gephi package to point to the latest 0.8.2 beta
- The Ubuntu ppa hasn't been updated in over two years, so I removed it entirely.